### PR TITLE
Session service with SHA-256 token hashing

### DIFF
--- a/backend/app/services/session_service.py
+++ b/backend/app/services/session_service.py
@@ -1,0 +1,169 @@
+"""Session service — manages server-side authentication sessions.
+
+Provides functions to create, validate, revoke, and clean up
+sessions stored in PostgreSQL with SHA-256 hashed tokens.
+"""
+
+import uuid
+from datetime import datetime, timedelta, timezone
+
+from sqlmodel import select
+
+from app.config import Config
+from app.database import get_session
+from app.models.session import Session
+from app.models.user import User
+from app.utils.tokens import generate_token, hash_token
+
+
+def create_session(
+    user_id: uuid.UUID,
+    ip_address: str | None = None,
+    user_agent: str | None = None,
+) -> str:
+    """Create a new session for a user and return the raw token.
+
+    Args:
+        user_id: The user's UUID.
+        ip_address: Optional client IP address for auditing.
+        user_agent: Optional client user-agent string for auditing.
+
+    Returns:
+        The raw (unhashed) session token to send to the client.
+    """
+    raw_token = generate_token()
+    hashed = hash_token(raw_token)
+    expires_at = datetime.now(timezone.utc) + timedelta(days=Config.SESSION_DURATION_DAYS)
+
+    session = Session(
+        user_id=user_id,
+        token=hashed,
+        expires_at=expires_at,
+        ip_address=ip_address,
+        user_agent=user_agent,
+    )
+
+    with get_session() as db:
+        db.add(session)
+        db.commit()
+
+    return raw_token
+
+
+def validate_session(token: str) -> dict | None:
+    """Validate a session token and return user info if valid.
+
+    If the session exists but is expired, it is deleted and None is returned.
+
+    Args:
+        token: The raw session token from the client cookie.
+
+    Returns:
+        A dict with session_id and user info, or None if invalid/expired.
+    """
+    hashed = hash_token(token)
+
+    with get_session() as db:
+        session = db.exec(select(Session).where(Session.token == hashed)).first()
+
+        if session is None:
+            return None
+
+        expires = session.expires_at if session.expires_at.tzinfo else session.expires_at.replace(tzinfo=timezone.utc)
+        if expires <= datetime.now(timezone.utc):
+            db.delete(session)
+            db.commit()
+            return None
+
+        user = db.get(User, session.user_id)
+
+        return {
+            "session_id": session.id,
+            "user": {
+                "id": user.id,
+                "email": user.email,
+                "first_name": user.first_name,
+                "last_name": user.last_name,
+                "role": user.role,
+                "email_verified": user.email_verified,
+            },
+        }
+
+
+def revoke_session(token: str) -> None:
+    """Revoke a session by its raw token.
+
+    Idempotent — does nothing if the token is not found.
+
+    Args:
+        token: The raw session token to revoke.
+    """
+    hashed = hash_token(token)
+
+    with get_session() as db:
+        session = db.exec(select(Session).where(Session.token == hashed)).first()
+        if session is not None:
+            db.delete(session)
+            db.commit()
+
+
+def revoke_all_user_sessions(user_id: uuid.UUID) -> None:
+    """Revoke all sessions for a given user.
+
+    Args:
+        user_id: The user's UUID.
+    """
+    with get_session() as db:
+        sessions = db.exec(select(Session).where(Session.user_id == user_id)).all()
+        for session in sessions:
+            db.delete(session)
+        db.commit()
+
+
+def get_user_sessions(user_id: uuid.UUID) -> list[dict]:
+    """Get all active sessions for a user, newest first.
+
+    Args:
+        user_id: The user's UUID.
+
+    Returns:
+        A list of session dicts with id, ip_address, user_agent,
+        created_at, and expires_at.
+    """
+    now = datetime.now(timezone.utc)
+
+    with get_session() as db:
+        sessions = db.exec(
+            select(Session)
+            .where(Session.user_id == user_id, Session.expires_at > now)
+            .order_by(Session.created_at.desc())
+        ).all()
+
+        return [
+            {
+                "id": s.id,
+                "ip_address": s.ip_address,
+                "user_agent": s.user_agent,
+                "created_at": s.created_at,
+                "expires_at": s.expires_at,
+            }
+            for s in sessions
+        ]
+
+
+def cleanup_expired_sessions() -> int:
+    """Delete all expired sessions from the database.
+
+    Returns:
+        The number of sessions deleted.
+    """
+    now = datetime.now(timezone.utc)
+
+    with get_session() as db:
+        expired = db.exec(select(Session).where(Session.expires_at <= now)).all()
+        count = len(expired)
+        for session in expired:
+            db.delete(session)
+        db.commit()
+
+    return count

--- a/backend/app/utils/tokens.py
+++ b/backend/app/utils/tokens.py
@@ -1,12 +1,11 @@
 """Token generation and hashing utilities.
 
 Provides functions to generate cryptographically secure URL-safe tokens
-and to hash/verify them using bcrypt.
+and to hash/verify them using SHA-256.
 """
 
+import hashlib
 import secrets
-
-from app.utils.hashing import bcrypt_hash, bcrypt_verify
 
 
 def generate_token(nbytes: int = 32) -> str:
@@ -22,25 +21,25 @@ def generate_token(nbytes: int = 32) -> str:
 
 
 def hash_token(token: str) -> str:
-    """Hash a plaintext token using bcrypt with cost factor 12.
+    """Hash a plaintext token using SHA-256.
 
     Args:
         token: The plaintext token to hash.
 
     Returns:
-        The bcrypt hash as a UTF-8 string.
+        The hex-encoded SHA-256 digest (64 characters).
     """
-    return bcrypt_hash(token)
+    return hashlib.sha256(token.encode()).hexdigest()
 
 
 def verify_token(token: str, hashed: str) -> bool:
-    """Verify a plaintext token against a bcrypt hash.
+    """Verify a plaintext token against a SHA-256 hash.
 
     Args:
         token: The plaintext token to check.
-        hashed: The stored bcrypt hash to verify against.
+        hashed: The stored SHA-256 hex digest to verify against.
 
     Returns:
         True if the token matches the hash, False otherwise.
     """
-    return bcrypt_verify(token, hashed)
+    return hash_token(token) == hashed

--- a/backend/tests/services/test_session_service.py
+++ b/backend/tests/services/test_session_service.py
@@ -1,0 +1,304 @@
+"""Tests for session service functions.
+
+Verifies session creation, validation, revocation, and cleanup
+using an in-memory SQLite database with patched get_session.
+"""
+
+import uuid
+from contextlib import contextmanager
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+
+from sqlmodel import Session, SQLModel, create_engine, select
+
+from app.models.enums import Role
+from app.models.session import Session as SessionModel
+from app.models.user import User
+from app.services.session_service import (
+    cleanup_expired_sessions,
+    create_session,
+    get_user_sessions,
+    revoke_all_user_sessions,
+    revoke_session,
+    validate_session,
+)
+from app.utils.tokens import hash_token
+
+
+def _make_user(db: Session, **overrides) -> User:
+    """Insert a User with sensible defaults and return it."""
+    defaults = {
+        "id": uuid.uuid4(),
+        "email": f"{uuid.uuid4().hex[:8]}@example.com",
+        "password_hash": "$2b$12$fakehashvalue",
+        "first_name": "Test",
+        "last_name": "User",
+        "role": Role.CLIENT,
+        "email_verified": False,
+    }
+    defaults.update(overrides)
+    user = User(**defaults)
+    db.add(user)
+    db.flush()
+    return user
+
+
+@contextmanager
+def _patched_session(db: Session):
+    """Patch get_session to yield the test db with commit → flush."""
+    original_commit = db.commit
+
+    def _flush_instead():
+        db.flush()
+
+    db.commit = _flush_instead
+
+    @contextmanager
+    def _fake_get_session():
+        yield db
+
+    try:
+        with patch("app.services.session_service.get_session", _fake_get_session):
+            yield db
+    finally:
+        db.commit = original_commit
+
+
+def _make_engine_and_session():
+    """Create an in-memory SQLite engine and session."""
+    engine = create_engine("sqlite://", echo=False)
+    SQLModel.metadata.create_all(engine)
+    return engine, Session(engine)
+
+
+class TestCreateSession:
+    """Tests for create_session."""
+
+    def test_returns_token_string(self):
+        """create_session should return a raw token string."""
+        engine, db = _make_engine_and_session()
+        with db:
+            user = _make_user(db)
+            with _patched_session(db):
+                token = create_session(user.id)
+            assert isinstance(token, str)
+            assert len(token) >= 40
+
+    def test_stores_hashed_token_in_db(self):
+        """The stored token should be the SHA-256 hash of the raw token."""
+        engine, db = _make_engine_and_session()
+        with db:
+            user = _make_user(db)
+            with _patched_session(db):
+                token = create_session(user.id)
+            row = db.exec(select(SessionModel)).first()
+            assert row.token == hash_token(token)
+
+    def test_sets_30_day_expiry(self):
+        """Session should expire approximately 30 days from now."""
+        engine, db = _make_engine_and_session()
+        with db:
+            user = _make_user(db)
+            with _patched_session(db):
+                token = create_session(user.id)
+            row = db.exec(select(SessionModel)).first()
+            expected = datetime.now(timezone.utc).replace(tzinfo=None) + timedelta(days=30)
+            delta = abs((row.expires_at.replace(tzinfo=None) - expected).total_seconds())
+            assert delta < 5
+
+    def test_stores_ip_and_user_agent(self):
+        """create_session should store optional ip_address and user_agent."""
+        engine, db = _make_engine_and_session()
+        with db:
+            user = _make_user(db)
+            with _patched_session(db):
+                create_session(user.id, ip_address="1.2.3.4", user_agent="TestBrowser")
+            row = db.exec(select(SessionModel)).first()
+            assert row.ip_address == "1.2.3.4"
+            assert row.user_agent == "TestBrowser"
+
+
+class TestValidateSession:
+    """Tests for validate_session."""
+
+    def test_valid_token_returns_user_dict(self):
+        """validate_session should return a dict with session_id and user info."""
+        engine, db = _make_engine_and_session()
+        with db:
+            user = _make_user(db, email="valid@example.com", first_name="Alice", last_name="Smith")
+            with _patched_session(db):
+                token = create_session(user.id)
+                result = validate_session(token)
+            assert result is not None
+            assert "session_id" in result
+            assert result["user"]["email"] == "valid@example.com"
+            assert result["user"]["first_name"] == "Alice"
+            assert result["user"]["last_name"] == "Smith"
+            assert result["user"]["role"] == Role.CLIENT
+
+    def test_missing_token_returns_none(self):
+        """validate_session should return None for a token not in DB."""
+        engine, db = _make_engine_and_session()
+        with db:
+            with _patched_session(db):
+                result = validate_session("nonexistent-token")
+            assert result is None
+
+    def test_expired_token_returns_none_and_deletes(self):
+        """validate_session should return None and delete expired sessions."""
+        engine, db = _make_engine_and_session()
+        with db:
+            user = _make_user(db)
+            with _patched_session(db):
+                token = create_session(user.id)
+            # Manually expire the session
+            row = db.exec(select(SessionModel)).first()
+            row.expires_at = datetime.now(timezone.utc) - timedelta(hours=1)
+            db.flush()
+            with _patched_session(db):
+                result = validate_session(token)
+            assert result is None
+            remaining = db.exec(select(SessionModel)).all()
+            assert len(remaining) == 0
+
+
+class TestRevokeSession:
+    """Tests for revoke_session."""
+
+    def test_deletes_session(self):
+        """revoke_session should remove the session from DB."""
+        engine, db = _make_engine_and_session()
+        with db:
+            user = _make_user(db)
+            with _patched_session(db):
+                token = create_session(user.id)
+                revoke_session(token)
+            remaining = db.exec(select(SessionModel)).all()
+            assert len(remaining) == 0
+
+    def test_idempotent_on_missing_token(self):
+        """revoke_session should not raise for a token not in DB."""
+        engine, db = _make_engine_and_session()
+        with db:
+            with _patched_session(db):
+                revoke_session("nonexistent-token")
+
+
+class TestRevokeAllUserSessions:
+    """Tests for revoke_all_user_sessions."""
+
+    def test_deletes_all_user_sessions(self):
+        """Should delete all sessions for the given user."""
+        engine, db = _make_engine_and_session()
+        with db:
+            user = _make_user(db)
+            with _patched_session(db):
+                create_session(user.id)
+                create_session(user.id)
+                create_session(user.id)
+                revoke_all_user_sessions(user.id)
+            remaining = db.exec(select(SessionModel)).all()
+            assert len(remaining) == 0
+
+    def test_does_not_affect_other_users(self):
+        """Should only delete sessions for the specified user."""
+        engine, db = _make_engine_and_session()
+        with db:
+            user1 = _make_user(db)
+            user2 = _make_user(db)
+            with _patched_session(db):
+                create_session(user1.id)
+                create_session(user2.id)
+                revoke_all_user_sessions(user1.id)
+            remaining = db.exec(select(SessionModel)).all()
+            assert len(remaining) == 1
+            assert remaining[0].user_id == user2.id
+
+
+class TestGetUserSessions:
+    """Tests for get_user_sessions."""
+
+    def test_returns_active_sessions_newest_first(self):
+        """Should return sessions ordered by created_at descending."""
+        engine, db = _make_engine_and_session()
+        with db:
+            user = _make_user(db)
+            with _patched_session(db):
+                create_session(user.id, ip_address="1.1.1.1")
+                create_session(user.id, ip_address="2.2.2.2")
+                sessions = get_user_sessions(user.id)
+            assert len(sessions) == 2
+            assert sessions[0]["ip_address"] == "2.2.2.2"
+            assert sessions[1]["ip_address"] == "1.1.1.1"
+
+    def test_excludes_expired(self):
+        """Should not return expired sessions."""
+        engine, db = _make_engine_and_session()
+        with db:
+            user = _make_user(db)
+            with _patched_session(db):
+                create_session(user.id)
+            # Expire the session
+            row = db.exec(select(SessionModel)).first()
+            row.expires_at = datetime.now(timezone.utc) - timedelta(hours=1)
+            db.flush()
+            with _patched_session(db):
+                sessions = get_user_sessions(user.id)
+            assert len(sessions) == 0
+
+    def test_empty_list_when_none(self):
+        """Should return empty list when user has no sessions."""
+        engine, db = _make_engine_and_session()
+        with db:
+            user = _make_user(db)
+            with _patched_session(db):
+                sessions = get_user_sessions(user.id)
+            assert sessions == []
+
+
+class TestCleanupExpiredSessions:
+    """Tests for cleanup_expired_sessions."""
+
+    def test_deletes_expired_returns_count(self):
+        """Should delete expired sessions and return the count."""
+        engine, db = _make_engine_and_session()
+        with db:
+            user = _make_user(db)
+            with _patched_session(db):
+                create_session(user.id)
+                create_session(user.id)
+            # Expire both sessions
+            for row in db.exec(select(SessionModel)).all():
+                row.expires_at = datetime.now(timezone.utc) - timedelta(hours=1)
+            db.flush()
+            with _patched_session(db):
+                count = cleanup_expired_sessions()
+            assert count == 2
+            remaining = db.exec(select(SessionModel)).all()
+            assert len(remaining) == 0
+
+    def test_preserves_active(self):
+        """Should not delete active sessions."""
+        engine, db = _make_engine_and_session()
+        with db:
+            user = _make_user(db)
+            with _patched_session(db):
+                create_session(user.id)
+                create_session(user.id)
+            # Expire only one
+            rows = db.exec(select(SessionModel)).all()
+            rows[0].expires_at = datetime.now(timezone.utc) - timedelta(hours=1)
+            db.flush()
+            with _patched_session(db):
+                count = cleanup_expired_sessions()
+            assert count == 1
+            remaining = db.exec(select(SessionModel)).all()
+            assert len(remaining) == 1
+
+    def test_returns_zero_when_none(self):
+        """Should return 0 when there are no expired sessions."""
+        engine, db = _make_engine_and_session()
+        with db:
+            with _patched_session(db):
+                count = cleanup_expired_sessions()
+            assert count == 0

--- a/backend/tests/test_tokens.py
+++ b/backend/tests/test_tokens.py
@@ -51,18 +51,19 @@ class TestHashToken:
         result = hash_token(token)
         assert isinstance(result, str)
 
-    def test_returns_bcrypt_hash(self):
-        """hash_token should return a valid bcrypt hash."""
+    def test_returns_64_char_hex(self):
+        """hash_token should return a 64-character hex string."""
         token = generate_token()
         result = hash_token(token)
-        assert result.startswith("$2b$12$")
+        assert len(result) == 64
+        assert all(c in "0123456789abcdef" for c in result)
 
-    def test_different_calls_produce_different_hashes(self):
-        """Each call should produce a unique hash due to random salt."""
+    def test_deterministic(self):
+        """Same input should always produce the same hash."""
         token = generate_token()
         hash1 = hash_token(token)
         hash2 = hash_token(token)
-        assert hash1 != hash2
+        assert hash1 == hash2
 
 
 class TestVerifyToken:

--- a/scripts/rename-branch.sh
+++ b/scripts/rename-branch.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Rename a git branch locally and on origin in one step.
+# Usage: ./scripts/rename-branch.sh <old-name> <new-name>
+set -euo pipefail
+
+# Require exactly two arguments
+if [ $# -ne 2 ]; then
+  echo "Usage: $(basename "$0") <old-name> <new-name>"
+  exit 1
+fi
+
+old="$1"
+new="$2"
+
+# Rename the local branch (works whether or not it's checked out)
+git branch -m "$old" "$new"
+
+# Delete the old branch on origin if it exists
+if git ls-remote --exit-code --heads origin "$old" >/dev/null 2>&1; then
+  git push origin :"$old"
+fi
+
+# Push the new branch and set up tracking
+git push -u origin "$new"
+
+echo "Renamed '$old' → '$new' (local + origin)"


### PR DESCRIPTION
## Summary
- Rewrite `hash_token`/`verify_token` from bcrypt to SHA-256 for deterministic DB lookups
- Implement session service with six functions: `create_session`, `validate_session`, `revoke_session`, `revoke_all_user_sessions`, `get_user_sessions`, `cleanup_expired_sessions`
- Add comprehensive tests for all session service functions using in-memory SQLite

## Test plan
- [x] Run `pytest tests/test_tokens.py` — verify SHA-256 hashing is deterministic and produces 64-char hex
- [x] Run `pytest tests/services/test_session_service.py` — verify all session CRUD and cleanup operations

Closes #35