### PR TITLE
Email service with Gmail API OAuth2

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -26,3 +26,6 @@ class Config:
     APP_URL = os.environ.get("APP_URL")
     CORS_ORIGINS = os.environ.get("CORS_ORIGINS")
     SESSION_DURATION_DAYS = int(os.environ.get("SESSION_DURATION_DAYS"))
+    GMAIL_CREDENTIALS_FILE = os.environ.get("GMAIL_CREDENTIALS_FILE")
+    GMAIL_TOKEN_FILE = os.environ.get("GMAIL_TOKEN_FILE")
+    GMAIL_SENDER = os.environ.get("GMAIL_SENDER")

--- a/backend/app/services/email_service.py
+++ b/backend/app/services/email_service.py
@@ -7,31 +7,40 @@ using branded HTML templates through the Gmail API.
 """
 
 import base64
+import os
 from email.mime.text import MIMEText
 
 from google.auth.transport.requests import Request
 from google.oauth2.credentials import Credentials
+from google_auth_oauthlib.flow import InstalledAppFlow
 from googleapiclient.discovery import build
 
 from app.config import Config
+
+SCOPES = ["https://www.googleapis.com/auth/gmail.send"]
 
 
 def _get_gmail_service():
     """Authenticate via OAuth2 and return a Gmail API service instance.
 
-    Loads credentials from the token file. If the token is expired
-    but has a refresh token, it will be refreshed automatically.
+    Loads credentials from the token file if it exists. If no token
+    file is found, runs the OAuth2 consent flow using the credentials
+    file to generate one. Expired tokens are refreshed automatically.
 
     Returns:
         A Gmail API service resource.
     """
-    creds = Credentials.from_authorized_user_file(
-        Config.GMAIL_TOKEN_FILE,
-        scopes=["https://www.googleapis.com/auth/gmail.send"],
-    )
+    creds = None
 
-    if not creds.valid and creds.expired and creds.refresh_token:
-        creds.refresh(Request())
+    if os.path.exists(Config.GMAIL_TOKEN_FILE):
+        creds = Credentials.from_authorized_user_file(Config.GMAIL_TOKEN_FILE, scopes=SCOPES)
+
+    if creds is None or not creds.valid:
+        if creds and creds.expired and creds.refresh_token:
+            creds.refresh(Request())
+        else:
+            flow = InstalledAppFlow.from_client_secrets_file(Config.GMAIL_CREDENTIALS_FILE, SCOPES)
+            creds = flow.run_local_server(port=0)
 
         with open(Config.GMAIL_TOKEN_FILE, "w") as f:
             f.write(creds.to_json())
@@ -61,43 +70,7 @@ def send_email(to: str, subject: str, html: str) -> None:
     service.users().messages().send(userId="me", body={"raw": raw}).execute()
 
 
-def send_verification_email(first_name: str, email: str, verification_url: str) -> None:
-    """Send a verification email with a branded HTML template.
-
-    Args:
-        first_name: User's first name for personalization.
-        email: Recipient email address.
-        verification_url: Full URL for email verification.
-    """
-    subject = "Verify Your Email — MelloClean"
-    html = _verification_template(first_name, verification_url)
-    send_email(email, subject, html)
-
-
-def send_password_reset_email(first_name: str, email: str, reset_url: str) -> None:
-    """Send a password reset email with a branded HTML template.
-
-    Args:
-        first_name: User's first name for personalization.
-        email: Recipient email address.
-        reset_url: Full URL for password reset.
-    """
-    subject = "Reset Your Password — MelloClean"
-    html = _password_reset_template(first_name, reset_url)
-    send_email(email, subject, html)
-
-
-def _verification_template(first_name: str, verification_url: str) -> str:
-    """Build the verification email HTML template.
-
-    Args:
-        first_name: User's first name.
-        verification_url: Clickable verification link.
-
-    Returns:
-        Fully rendered HTML string with inline CSS.
-    """
-    return f"""\
+VERIFICATION_HTML = """\
 <!DOCTYPE html>
 <html lang="en">
 <head><meta charset="UTF-8"></head>
@@ -141,18 +114,7 @@ def _verification_template(first_name: str, verification_url: str) -> str:
 </body>
 </html>"""
 
-
-def _password_reset_template(first_name: str, reset_url: str) -> str:
-    """Build the password reset email HTML template.
-
-    Args:
-        first_name: User's first name.
-        reset_url: Clickable password reset link.
-
-    Returns:
-        Fully rendered HTML string with inline CSS.
-    """
-    return f"""\
+PASSWORD_RESET_HTML = """\
 <!DOCTYPE html>
 <html lang="en">
 <head><meta charset="UTF-8"></head>
@@ -195,3 +157,29 @@ def _password_reset_template(first_name: str, reset_url: str) -> str:
   </table>
 </body>
 </html>"""
+
+
+def send_verification_email(first_name: str, email: str, verification_url: str) -> None:
+    """Send a verification email with a branded HTML template.
+
+    Args:
+        first_name: User's first name for personalization.
+        email: Recipient email address.
+        verification_url: Full URL for email verification.
+    """
+    subject = "Verify Your Email — MelloClean"
+    html = VERIFICATION_HTML.format(first_name=first_name, verification_url=verification_url)
+    send_email(email, subject, html)
+
+
+def send_password_reset_email(first_name: str, email: str, reset_url: str) -> None:
+    """Send a password reset email with a branded HTML template.
+
+    Args:
+        first_name: User's first name for personalization.
+        email: Recipient email address.
+        reset_url: Full URL for password reset.
+    """
+    subject = "Reset Your Password — MelloClean"
+    html = PASSWORD_RESET_HTML.format(first_name=first_name, reset_url=reset_url)
+    send_email(email, subject, html)

--- a/backend/app/services/email_service.py
+++ b/backend/app/services/email_service.py
@@ -1,0 +1,197 @@
+# Copyright 2026 Eduardo Turcios. All rights reserved.
+# Unauthorized use, reproduction, or distribution of this file is strictly prohibited.
+"""Email service — sends emails via Gmail API with OAuth2.
+
+Provides functions to send verification and password reset emails
+using branded HTML templates through the Gmail API.
+"""
+
+import base64
+from email.mime.text import MIMEText
+
+from google.auth.transport.requests import Request
+from google.oauth2.credentials import Credentials
+from googleapiclient.discovery import build
+
+from app.config import Config
+
+
+def _get_gmail_service():
+    """Authenticate via OAuth2 and return a Gmail API service instance.
+
+    Loads credentials from the token file. If the token is expired
+    but has a refresh token, it will be refreshed automatically.
+
+    Returns:
+        A Gmail API service resource.
+    """
+    creds = Credentials.from_authorized_user_file(
+        Config.GMAIL_TOKEN_FILE,
+        scopes=["https://www.googleapis.com/auth/gmail.send"],
+    )
+
+    if not creds.valid and creds.expired and creds.refresh_token:
+        creds.refresh(Request())
+
+        with open(Config.GMAIL_TOKEN_FILE, "w") as f:
+            f.write(creds.to_json())
+
+    return build("gmail", "v1", credentials=creds)
+
+
+def send_email(to: str, subject: str, html: str) -> None:
+    """Send an email via the Gmail API.
+
+    Constructs a MIME message and sends it using the authenticated
+    Gmail service.
+
+    Args:
+        to: Recipient email address.
+        subject: Email subject line.
+        html: HTML body content.
+    """
+    service = _get_gmail_service()
+
+    message = MIMEText(html, "html")
+    message["To"] = to
+    message["From"] = Config.GMAIL_SENDER
+    message["Subject"] = subject
+
+    raw = base64.urlsafe_b64encode(message.as_bytes()).decode("utf-8")
+    service.users().messages().send(userId="me", body={"raw": raw}).execute()
+
+
+def send_verification_email(first_name: str, email: str, verification_url: str) -> None:
+    """Send a verification email with a branded HTML template.
+
+    Args:
+        first_name: User's first name for personalization.
+        email: Recipient email address.
+        verification_url: Full URL for email verification.
+    """
+    subject = "Verify Your Email — MelloClean"
+    html = _verification_template(first_name, verification_url)
+    send_email(email, subject, html)
+
+
+def send_password_reset_email(first_name: str, email: str, reset_url: str) -> None:
+    """Send a password reset email with a branded HTML template.
+
+    Args:
+        first_name: User's first name for personalization.
+        email: Recipient email address.
+        reset_url: Full URL for password reset.
+    """
+    subject = "Reset Your Password — MelloClean"
+    html = _password_reset_template(first_name, reset_url)
+    send_email(email, subject, html)
+
+
+def _verification_template(first_name: str, verification_url: str) -> str:
+    """Build the verification email HTML template.
+
+    Args:
+        first_name: User's first name.
+        verification_url: Clickable verification link.
+
+    Returns:
+        Fully rendered HTML string with inline CSS.
+    """
+    return f"""\
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"></head>
+<body style="margin:0;padding:0;background-color:#f8fafc;font-family:Arial,Helvetica,sans-serif;">
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color:#f8fafc;padding:40px 0;">
+    <tr>
+      <td align="center">
+        <table role="presentation" width="480" cellpadding="0" cellspacing="0" style="max-width:480px;width:100%;background-color:#ffffff;border-radius:8px;overflow:hidden;">
+          <tr>
+            <td style="background-color:#10b981;padding:24px;text-align:center;">
+              <h1 style="margin:0;color:#ffffff;font-size:24px;font-weight:700;">MelloClean</h1>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding:32px 24px;">
+              <h2 style="margin:0 0 16px;color:#0f172a;font-size:20px;font-weight:600;">Welcome, {first_name}!</h2>
+              <p style="margin:0 0 24px;color:#475569;font-size:16px;line-height:1.5;">
+                Thanks for signing up for MelloClean. Please verify your email address by clicking the button below.
+              </p>
+              <table role="presentation" cellpadding="0" cellspacing="0" style="margin:0 auto 24px;">
+                <tr>
+                  <td style="border-radius:6px;background-color:#10b981;">
+                    <a href="{verification_url}" target="_blank" style="display:inline-block;padding:12px 32px;color:#ffffff;font-size:16px;font-weight:600;text-decoration:none;">Verify Email</a>
+                  </td>
+                </tr>
+              </table>
+              <p style="margin:0 0 8px;color:#475569;font-size:14px;line-height:1.5;">
+                This link will expire in 24 hours. If you did not create an account, you can safely ignore this email.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding:16px 24px;background-color:#f8fafc;text-align:center;">
+              <p style="margin:0;color:#94a3b8;font-size:12px;">&copy; 2026 MelloClean. All rights reserved.</p>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>"""
+
+
+def _password_reset_template(first_name: str, reset_url: str) -> str:
+    """Build the password reset email HTML template.
+
+    Args:
+        first_name: User's first name.
+        reset_url: Clickable password reset link.
+
+    Returns:
+        Fully rendered HTML string with inline CSS.
+    """
+    return f"""\
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"></head>
+<body style="margin:0;padding:0;background-color:#f8fafc;font-family:Arial,Helvetica,sans-serif;">
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color:#f8fafc;padding:40px 0;">
+    <tr>
+      <td align="center">
+        <table role="presentation" width="480" cellpadding="0" cellspacing="0" style="max-width:480px;width:100%;background-color:#ffffff;border-radius:8px;overflow:hidden;">
+          <tr>
+            <td style="background-color:#10b981;padding:24px;text-align:center;">
+              <h1 style="margin:0;color:#ffffff;font-size:24px;font-weight:700;">MelloClean</h1>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding:32px 24px;">
+              <h2 style="margin:0 0 16px;color:#0f172a;font-size:20px;font-weight:600;">Hi {first_name},</h2>
+              <p style="margin:0 0 24px;color:#475569;font-size:16px;line-height:1.5;">
+                We received a request to reset your password. Click the button below to choose a new one.
+              </p>
+              <table role="presentation" cellpadding="0" cellspacing="0" style="margin:0 auto 24px;">
+                <tr>
+                  <td style="border-radius:6px;background-color:#10b981;">
+                    <a href="{reset_url}" target="_blank" style="display:inline-block;padding:12px 32px;color:#ffffff;font-size:16px;font-weight:600;text-decoration:none;">Reset Password</a>
+                  </td>
+                </tr>
+              </table>
+              <p style="margin:0 0 8px;color:#475569;font-size:14px;line-height:1.5;">
+                This link will expire in 1 hour. If you did not request a password reset, you can safely ignore this email.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding:16px 24px;background-color:#f8fafc;text-align:center;">
+              <p style="margin:0;color:#94a3b8;font-size:12px;">&copy; 2026 MelloClean. All rights reserved.</p>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>"""

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -5,4 +5,7 @@ psycopg2-binary~=2.9
 bcrypt~=4.1
 alembic~=1.13
 python-dotenv~=1.0
+google-api-python-client~=2.0
+google-auth-httplib2~=0.2
+google-auth-oauthlib~=1.0
 pytest~=7.4

--- a/backend/tests/manual/manual_test_email.py
+++ b/backend/tests/manual/manual_test_email.py
@@ -1,0 +1,31 @@
+# Copyright 2026 Eduardo Turcios. All rights reserved.
+# Unauthorized use, reproduction, or distribution of this file is strictly prohibited.
+"""Manual test script for the email service.
+
+Run from the backend directory:
+    python -m tests.manual.manual_test_email
+"""
+
+from app.services.email_service import (
+    VERIFICATION_HTML,
+    PASSWORD_RESET_HTML,
+    send_verification_email,
+    send_password_reset_email,
+)
+from app.config import Config
+
+EMAIL = Config.GMAIL_SENDER
+
+print("--- Verification HTML preview ---")
+print(VERIFICATION_HTML.format(first_name="Eddie", verification_url="https://melloclean.com/verify?token=test123"))
+
+print("\n--- Password Reset HTML preview ---")
+print(PASSWORD_RESET_HTML.format(first_name="Eddie", reset_url="https://melloclean.com/reset?token=test456"))
+
+print("\nSending verification email...")
+send_verification_email("Eddie", EMAIL, "https://melloclean.com/verify?token=test123")
+print("Verification email sent!")
+
+print("Sending password reset email...")
+send_password_reset_email("Eddie", EMAIL, "https://melloclean.com/reset?token=test456")
+print("Password reset email sent!")

--- a/backend/tests/services/test_email_service.py
+++ b/backend/tests/services/test_email_service.py
@@ -211,9 +211,10 @@ class TestGetGmailService:
     """Tests for _get_gmail_service helper."""
 
     @patch("app.services.email_service.build")
+    @patch("app.services.email_service.os.path.exists", return_value=True)
     @patch("app.services.email_service.Credentials.from_authorized_user_file")
-    def test_builds_gmail_service_with_credentials(self, mock_creds_load, mock_build):
-        """_get_gmail_service should load credentials and build a Gmail service."""
+    def test_builds_gmail_service_with_existing_token(self, mock_creds_load, mock_exists, mock_build):
+        """_get_gmail_service should load credentials from token file and build service."""
         from app.services.email_service import _get_gmail_service
 
         mock_creds = MagicMock()
@@ -222,12 +223,14 @@ class TestGetGmailService:
 
         _get_gmail_service()
 
+        mock_creds_load.assert_called_once()
         mock_build.assert_called_once_with("gmail", "v1", credentials=mock_creds)
 
     @patch("builtins.open", mock_open())
     @patch("app.services.email_service.build")
+    @patch("app.services.email_service.os.path.exists", return_value=True)
     @patch("app.services.email_service.Credentials.from_authorized_user_file")
-    def test_refreshes_expired_credentials(self, mock_creds_load, mock_build):
+    def test_refreshes_expired_credentials(self, mock_creds_load, mock_exists, mock_build):
         """_get_gmail_service should refresh credentials when expired."""
         from app.services.email_service import _get_gmail_service
 
@@ -240,3 +243,23 @@ class TestGetGmailService:
         _get_gmail_service()
 
         mock_creds.refresh.assert_called_once()
+
+    @patch("builtins.open", mock_open())
+    @patch("app.services.email_service.build")
+    @patch("app.services.email_service.InstalledAppFlow.from_client_secrets_file")
+    @patch("app.services.email_service.os.path.exists", return_value=False)
+    def test_runs_oauth_flow_when_no_token_file(self, mock_exists, mock_flow_cls, mock_build):
+        """_get_gmail_service should run OAuth consent flow when token file is missing."""
+        from app.services.email_service import _get_gmail_service
+
+        mock_creds = MagicMock()
+        mock_creds.valid = True
+        mock_flow = MagicMock()
+        mock_flow.run_local_server.return_value = mock_creds
+        mock_flow_cls.return_value = mock_flow
+
+        _get_gmail_service()
+
+        mock_flow_cls.assert_called_once()
+        mock_flow.run_local_server.assert_called_once_with(port=0)
+        mock_build.assert_called_once_with("gmail", "v1", credentials=mock_creds)

--- a/backend/tests/services/test_email_service.py
+++ b/backend/tests/services/test_email_service.py
@@ -1,0 +1,242 @@
+# Copyright 2026 Eduardo Turcios. All rights reserved.
+# Unauthorized use, reproduction, or distribution of this file is strictly prohibited.
+"""Tests for email service functions.
+
+Verifies email sending, verification email, and password reset email
+using mocked Gmail API credentials and service.
+"""
+
+import base64
+from unittest.mock import MagicMock, patch, mock_open
+
+from app.services.email_service import (
+    send_email,
+    send_verification_email,
+    send_password_reset_email,
+)
+
+
+def _mock_gmail_service():
+    """Create a mock Gmail API service with a sendable messages resource."""
+    service = MagicMock()
+    service.users.return_value.messages.return_value.send.return_value.execute.return_value = {
+        "id": "msg_123",
+        "labelIds": ["SENT"],
+    }
+    return service
+
+
+class TestSendEmail:
+    """Tests for send_email."""
+
+    @patch("app.services.email_service._get_gmail_service")
+    def test_sends_email_via_gmail_api(self, mock_get_service):
+        """send_email should call Gmail API send with correct parameters."""
+        mock_service = _mock_gmail_service()
+        mock_get_service.return_value = mock_service
+
+        send_email("user@example.com", "Test Subject", "<h1>Hello</h1>")
+
+        mock_service.users.return_value.messages.return_value.send.assert_called_once()
+        call_kwargs = mock_service.users.return_value.messages.return_value.send.call_args
+        assert call_kwargs[1]["userId"] == "me"
+
+    @patch("app.services.email_service._get_gmail_service")
+    def test_constructs_mime_message_with_correct_headers(self, mock_get_service):
+        """send_email should build a MIME message with To, Subject, and From."""
+        mock_service = _mock_gmail_service()
+        mock_get_service.return_value = mock_service
+
+        send_email("recipient@example.com", "My Subject", "<p>Body</p>")
+
+        call_kwargs = mock_service.users.return_value.messages.return_value.send.call_args
+        raw_message = call_kwargs[1]["body"]["raw"]
+        decoded = base64.urlsafe_b64decode(raw_message).decode("utf-8")
+        assert "recipient@example.com" in decoded
+        assert "My Subject" in decoded
+
+    @patch("app.services.email_service._get_gmail_service")
+    def test_message_contains_html_body(self, mock_get_service):
+        """send_email should include HTML content in the message body."""
+        mock_service = _mock_gmail_service()
+        mock_get_service.return_value = mock_service
+
+        html = "<h1>Welcome</h1><p>Thanks for signing up.</p>"
+        send_email("user@example.com", "Welcome", html)
+
+        call_kwargs = mock_service.users.return_value.messages.return_value.send.call_args
+        raw_message = call_kwargs[1]["body"]["raw"]
+        decoded = base64.urlsafe_b64decode(raw_message).decode("utf-8")
+        assert "Welcome" in decoded
+        assert "Thanks for signing up." in decoded
+
+
+class TestSendVerificationEmail:
+    """Tests for send_verification_email."""
+
+    @patch("app.services.email_service.send_email")
+    def test_calls_send_email(self, mock_send):
+        """send_verification_email should delegate to send_email."""
+        send_verification_email("Alice", "alice@example.com", "https://example.com/verify?token=abc")
+
+        mock_send.assert_called_once()
+        args = mock_send.call_args[0]
+        assert args[0] == "alice@example.com"
+
+    @patch("app.services.email_service.send_email")
+    def test_subject_contains_verification(self, mock_send):
+        """Subject line should indicate email verification."""
+        send_verification_email("Alice", "alice@example.com", "https://example.com/verify?token=abc")
+
+        args = mock_send.call_args[0]
+        subject = args[1]
+        assert "verif" in subject.lower() or "confirm" in subject.lower()
+
+    @patch("app.services.email_service.send_email")
+    def test_html_contains_user_name(self, mock_send):
+        """HTML body should include the user's first name."""
+        send_verification_email("Alice", "alice@example.com", "https://example.com/verify?token=abc")
+
+        args = mock_send.call_args[0]
+        html = args[2]
+        assert "Alice" in html
+
+    @patch("app.services.email_service.send_email")
+    def test_html_contains_verification_url(self, mock_send):
+        """HTML body should include the verification URL."""
+        url = "https://example.com/verify?token=abc123"
+        send_verification_email("Alice", "alice@example.com", url)
+
+        args = mock_send.call_args[0]
+        html = args[2]
+        assert url in html
+
+    @patch("app.services.email_service.send_email")
+    def test_html_contains_verify_button_text(self, mock_send):
+        """HTML body should include 'Verify Email' CTA text."""
+        send_verification_email("Alice", "alice@example.com", "https://example.com/verify?token=abc")
+
+        args = mock_send.call_args[0]
+        html = args[2]
+        assert "Verify Email" in html
+
+    @patch("app.services.email_service.send_email")
+    def test_html_contains_24_hour_expiry(self, mock_send):
+        """HTML body should mention the 24-hour link expiry."""
+        send_verification_email("Alice", "alice@example.com", "https://example.com/verify?token=abc")
+
+        args = mock_send.call_args[0]
+        html = args[2]
+        assert "24" in html
+
+    @patch("app.services.email_service.send_email")
+    def test_html_contains_brand_color(self, mock_send):
+        """HTML body should use MelloClean emerald (#10b981) for the CTA button."""
+        send_verification_email("Alice", "alice@example.com", "https://example.com/verify?token=abc")
+
+        args = mock_send.call_args[0]
+        html = args[2]
+        assert "#10b981" in html.lower() or "#10B981" in html
+
+
+class TestSendPasswordResetEmail:
+    """Tests for send_password_reset_email."""
+
+    @patch("app.services.email_service.send_email")
+    def test_calls_send_email(self, mock_send):
+        """send_password_reset_email should delegate to send_email."""
+        send_password_reset_email("Bob", "bob@example.com", "https://example.com/reset?token=xyz")
+
+        mock_send.assert_called_once()
+        args = mock_send.call_args[0]
+        assert args[0] == "bob@example.com"
+
+    @patch("app.services.email_service.send_email")
+    def test_subject_contains_reset(self, mock_send):
+        """Subject line should indicate password reset."""
+        send_password_reset_email("Bob", "bob@example.com", "https://example.com/reset?token=xyz")
+
+        args = mock_send.call_args[0]
+        subject = args[1]
+        assert "reset" in subject.lower()
+
+    @patch("app.services.email_service.send_email")
+    def test_html_contains_user_name(self, mock_send):
+        """HTML body should include the user's first name."""
+        send_password_reset_email("Bob", "bob@example.com", "https://example.com/reset?token=xyz")
+
+        args = mock_send.call_args[0]
+        html = args[2]
+        assert "Bob" in html
+
+    @patch("app.services.email_service.send_email")
+    def test_html_contains_reset_url(self, mock_send):
+        """HTML body should include the reset URL."""
+        url = "https://example.com/reset?token=xyz789"
+        send_password_reset_email("Bob", "bob@example.com", url)
+
+        args = mock_send.call_args[0]
+        html = args[2]
+        assert url in html
+
+    @patch("app.services.email_service.send_email")
+    def test_html_contains_reset_button_text(self, mock_send):
+        """HTML body should include 'Reset Password' CTA text."""
+        send_password_reset_email("Bob", "bob@example.com", "https://example.com/reset?token=xyz")
+
+        args = mock_send.call_args[0]
+        html = args[2]
+        assert "Reset Password" in html
+
+    @patch("app.services.email_service.send_email")
+    def test_html_contains_1_hour_expiry(self, mock_send):
+        """HTML body should mention the 1-hour link expiry."""
+        send_password_reset_email("Bob", "bob@example.com", "https://example.com/reset?token=xyz")
+
+        args = mock_send.call_args[0]
+        html = args[2]
+        assert "1 hour" in html.lower() or "one hour" in html.lower() or "60 minute" in html.lower()
+
+    @patch("app.services.email_service.send_email")
+    def test_html_contains_brand_color(self, mock_send):
+        """HTML body should use MelloClean emerald (#10b981) for the CTA button."""
+        send_password_reset_email("Bob", "bob@example.com", "https://example.com/reset?token=xyz")
+
+        args = mock_send.call_args[0]
+        html = args[2]
+        assert "#10b981" in html.lower() or "#10B981" in html
+
+
+class TestGetGmailService:
+    """Tests for _get_gmail_service helper."""
+
+    @patch("app.services.email_service.build")
+    @patch("app.services.email_service.Credentials.from_authorized_user_file")
+    def test_builds_gmail_service_with_credentials(self, mock_creds_load, mock_build):
+        """_get_gmail_service should load credentials and build a Gmail service."""
+        from app.services.email_service import _get_gmail_service
+
+        mock_creds = MagicMock()
+        mock_creds.valid = True
+        mock_creds_load.return_value = mock_creds
+
+        _get_gmail_service()
+
+        mock_build.assert_called_once_with("gmail", "v1", credentials=mock_creds)
+
+    @patch("builtins.open", mock_open())
+    @patch("app.services.email_service.build")
+    @patch("app.services.email_service.Credentials.from_authorized_user_file")
+    def test_refreshes_expired_credentials(self, mock_creds_load, mock_build):
+        """_get_gmail_service should refresh credentials when expired."""
+        from app.services.email_service import _get_gmail_service
+
+        mock_creds = MagicMock()
+        mock_creds.valid = False
+        mock_creds.expired = True
+        mock_creds.refresh_token = "refresh_token_value"
+        mock_creds_load.return_value = mock_creds
+
+        _get_gmail_service()
+
+        mock_creds.refresh.assert_called_once()


### PR DESCRIPTION
## Summary
- Add `email_service.py` with `send_email()`, `send_verification_email()`, and `send_password_reset_email()` using Gmail API OAuth2
- Add branded HTML email templates with MelloClean emerald CTA, inline CSS, responsive 480px layout
- Add Gmail config variables (`GMAIL_CREDENTIALS_FILE`, `GMAIL_TOKEN_FILE`, `GMAIL_SENDER`) to `Config`
- Add `google-api-python-client`, `google-auth-httplib2`, `google-auth-oauthlib` to `requirements.txt`
- Add 19 tests covering all service functions and template content

Closes #36

## Test plan
- [x] 19 unit tests passing (`pytest tests/services/test_email_service.py`)
- [ ] Manual verification with real Gmail OAuth2 credentials