### PR TITLE
Frontend API types for Flask responses (#40)

### DIFF
--- a/backend/app/blueprints/admin.py
+++ b/backend/app/blueprints/admin.py
@@ -7,7 +7,6 @@ All routes require authentication and the ADMIN role. Registered
 under the ``/api/admin`` prefix by the app factory.
 """
 
-import re
 import uuid
 from http import HTTPStatus
 
@@ -21,43 +20,21 @@ from app.models.user import User
 from app.response import error, paginated, success, success_action, validation_error
 from app.services.session_service import revoke_all_user_sessions
 from app.utils.password import hash_password
+from app.utils.validation import (
+    serialize_user,
+    validate_confirm_password,
+    validate_email,
+    validate_name,
+    validate_password,
+)
 
 admin_bp = Blueprint("admin", __name__)
-
-"""Minimum password length enforced at the route level."""
-_MIN_PASSWORD_LENGTH = 8
-
-"""Email format regex matching the frontend validator."""
-_EMAIL_RE = re.compile(r"^[^\s@]+@[^\s@]+\.[^\s@]+$")
 
 """Set of valid role strings for admin user creation."""
 _VALID_ROLES = {r.value for r in Role}
 
 """Default page size for paginated user listings."""
 _DEFAULT_PER_PAGE = 25
-
-
-def _user_dict(user):
-    """Serialize a User model to a JSON-safe dict for admin use.
-
-    Includes id, role, and created_at since the admin dashboard needs them.
-
-    Args:
-        user: A User SQLModel instance.
-
-    Returns:
-        A dict with id, email, name, role, verification status, and creation time.
-    """
-    role = user.role.value if hasattr(user.role, "value") else str(user.role)
-    return {
-        "id": str(user.id),
-        "email": user.email,
-        "first_name": user.first_name,
-        "last_name": user.last_name,
-        "role": role,
-        "email_verified": user.email_verified,
-        "created_at": user.created_at.isoformat() if user.created_at else None,
-    }
 
 
 @admin_bp.route("/users", methods=["GET"])
@@ -84,7 +61,7 @@ def list_users():
                 select(User).order_by(User.created_at.desc())
             ).all()
             return paginated(
-                [_user_dict(u) for u in users],
+                [serialize_user(u) for u in users],
                 page=1,
                 page_size=len(users),
                 total=len(users),
@@ -105,7 +82,7 @@ def list_users():
         ).all()
 
         return paginated(
-            [_user_dict(u) for u in users],
+            [serialize_user(u) for u in users],
             page=page,
             page_size=per_page,
             total=total,
@@ -137,25 +114,10 @@ def create_user():
 
     errors = []
 
-    if not email:
-        errors.append({"field": "email", "issue": "Required"})
-    if email and not _EMAIL_RE.match(email):
-        errors.append({"field": "email", "issue": "Invalid format"})
-
-    if not password:
-        errors.append({"field": "password", "issue": "Required"})
-    if password and len(password) < _MIN_PASSWORD_LENGTH:
-        errors.append({"field": "password", "issue": f"Must be at least {_MIN_PASSWORD_LENGTH} characters"})
-
-    if not first_name:
-        errors.append({"field": "firstName", "issue": "Required"})
-    if not last_name:
-        errors.append({"field": "lastName", "issue": "Required"})
-
-    if not confirm_password:
-        errors.append({"field": "confirmPassword", "issue": "Required"})
-    if confirm_password and password and password != confirm_password:
-        errors.append({"field": "confirmPassword", "issue": "Passwords do not match"})
+    validate_email(email, errors)
+    validate_password(password, errors)
+    validate_name(first_name, last_name, errors)
+    validate_confirm_password(confirm_password, password, errors)
 
     if not role_str:
         errors.append({"field": "role", "issue": "Required"})
@@ -184,7 +146,7 @@ def create_user():
         db.commit()
         db.refresh(user)
 
-        return success(_user_dict(user), 201)
+        return success(serialize_user(user), 201)
 
 
 @admin_bp.route("/users/<user_id>/revoke-sessions", methods=["POST"])

--- a/backend/app/blueprints/admin.py
+++ b/backend/app/blueprints/admin.py
@@ -146,7 +146,7 @@ def create_user():
         db.commit()
         db.refresh(user)
 
-        return success(serialize_user(user), 201)
+        return success(serialize_user(user), HTTPStatus.CREATED)
 
 
 @admin_bp.route("/users/<user_id>/revoke-sessions", methods=["POST"])

--- a/backend/app/blueprints/auth.py
+++ b/backend/app/blueprints/auth.py
@@ -7,7 +7,6 @@ password reset, and verification resend routes. All routes are
 registered under the ``/api/auth`` prefix by the app factory.
 """
 
-import re
 from http import HTTPStatus
 
 from flask import Blueprint, g, jsonify, request
@@ -17,17 +16,16 @@ from app.middleware import set_session_cookie, clear_session_cookie
 from app.middleware.auth import require_auth
 from app.response import error, success, success_action, validation_error
 from app.services import auth_service
+from app.utils.validation import (
+    ZIP_RE,
+    serialize_user,
+    validate_confirm_password,
+    validate_email,
+    validate_name,
+    validate_password,
+)
 
 auth_bp = Blueprint("auth", __name__)
-
-"""Minimum password length enforced at the route level."""
-_MIN_PASSWORD_LENGTH = 8
-
-"""Email format regex matching the frontend validator."""
-_EMAIL_RE = re.compile(r"^[^\s@]+@[^\s@]+\.[^\s@]+$")
-
-"""US zip code regex matching the frontend validator."""
-_ZIP_RE = re.compile(r"^\d{5}$")
 
 """Maps AuthError codes to HTTP status codes."""
 _ERROR_STATUS = {
@@ -47,25 +45,6 @@ def _error_response(err: AuthError):
     """
     status = _ERROR_STATUS.get(err.code, HTTPStatus.BAD_REQUEST)
     return error(err.code, err.message, status)
-
-
-def _user_dict(user):
-    """Serialize a User model to a JSON-safe dict for client use.
-
-    Excludes id and role since the frontend does not need them.
-
-    Args:
-        user: A User SQLModel instance.
-
-    Returns:
-        A dict with email, name, and verification status.
-    """
-    return {
-        "email": user.email,
-        "first_name": user.first_name,
-        "last_name": user.last_name,
-        "email_verified": user.email_verified,
-    }
 
 
 @auth_bp.route("/signup", methods=["POST"])
@@ -95,25 +74,10 @@ def signup():
 
     errors = []
 
-    if not email:
-        errors.append({"field": "email", "issue": "Required"})
-    if email and not _EMAIL_RE.match(email):
-        errors.append({"field": "email", "issue": "Invalid format"})
-
-    if not password:
-        errors.append({"field": "password", "issue": "Required"})
-    if password and len(password) < _MIN_PASSWORD_LENGTH:
-        errors.append({"field": "password", "issue": f"Must be at least {_MIN_PASSWORD_LENGTH} characters"})
-
-    if not first_name:
-        errors.append({"field": "firstName", "issue": "Required"})
-    if not last_name:
-        errors.append({"field": "lastName", "issue": "Required"})
-
-    if not confirm_password:
-        errors.append({"field": "confirmPassword", "issue": "Required"})
-    if confirm_password and password and password != confirm_password:
-        errors.append({"field": "confirmPassword", "issue": "Passwords do not match"})
+    validate_email(email, errors)
+    validate_password(password, errors)
+    validate_name(first_name, last_name, errors)
+    validate_confirm_password(confirm_password, password, errors)
 
     if not street:
         errors.append({"field": "street", "issue": "Required"})
@@ -123,7 +87,7 @@ def signup():
         errors.append({"field": "state", "issue": "Required"})
     if not zip_code:
         errors.append({"field": "zipCode", "issue": "Required"})
-    if zip_code and not _ZIP_RE.match(zip_code):
+    if zip_code and not ZIP_RE.match(zip_code):
         errors.append({"field": "zipCode", "issue": "Must be 5 digits"})
 
     if errors:
@@ -145,7 +109,7 @@ def signup():
     except AuthError as e:
         return _error_response(e)
 
-    resp = jsonify({"data": {"user": _user_dict(result["user"])}})
+    resp = jsonify({"data": {"user": serialize_user(result["user"])}})
     set_session_cookie(resp, result["session_token"])
     return resp, HTTPStatus.CREATED
 
@@ -168,10 +132,7 @@ def login():
 
     errors = []
 
-    if not email:
-        errors.append({"field": "email", "issue": "Required"})
-    if email and not _EMAIL_RE.match(email):
-        errors.append({"field": "email", "issue": "Invalid format"})
+    validate_email(email, errors)
     if not password:
         errors.append({"field": "password", "issue": "Required"})
 
@@ -188,7 +149,7 @@ def login():
     except AuthError as e:
         return _error_response(e)
 
-    resp = jsonify({"data": {"user": _user_dict(result["user"])}})
+    resp = jsonify({"data": {"user": serialize_user(result["user"])}})
     set_session_cookie(resp, result["session_token"])
     return resp, HTTPStatus.OK
 
@@ -220,16 +181,7 @@ def me():
     Returns:
         200 with user info on success, 401 if not authenticated.
     """
-    user = g.user
-    role = user["role"].value if hasattr(user["role"], "value") else str(user["role"])
-    return success({
-        "id": str(user["id"]),
-        "email": user["email"],
-        "first_name": user["first_name"],
-        "last_name": user["last_name"],
-        "role": role,
-        "email_verified": user["email_verified"],
-    })
+    return success(serialize_user(g.user))
 
 
 @auth_bp.route("/verify-email", methods=["POST"])
@@ -294,14 +246,8 @@ def reset_password():
 
     if not token:
         errors.append({"field": "token", "issue": "Required"})
-    if not password:
-        errors.append({"field": "password", "issue": "Required"})
-    if password and len(password) < _MIN_PASSWORD_LENGTH:
-        errors.append({"field": "password", "issue": f"Must be at least {_MIN_PASSWORD_LENGTH} characters"})
-    if not confirm_password:
-        errors.append({"field": "confirmPassword", "issue": "Required"})
-    if confirm_password and password and password != confirm_password:
-        errors.append({"field": "confirmPassword", "issue": "Passwords do not match"})
+    validate_password(password, errors)
+    validate_confirm_password(confirm_password, password, errors)
 
     if errors:
         return validation_error(errors)

--- a/backend/app/services/session_service.py
+++ b/backend/app/services/session_service.py
@@ -88,6 +88,7 @@ def validate_session(token: str) -> dict | None:
                 "last_name": user.last_name,
                 "role": user.role,
                 "email_verified": user.email_verified,
+                "created_at": user.created_at,
             },
         }
 

--- a/backend/app/utils/validation.py
+++ b/backend/app/utils/validation.py
@@ -1,0 +1,113 @@
+# Copyright 2026 Eduardo Turcios. All rights reserved.
+# Unauthorized use, reproduction, or distribution of this file is strictly prohibited.
+"""Shared validation helpers and user serialization.
+
+Provides reusable field validators and a single ``serialize_user``
+function used by both the auth and admin blueprints.
+"""
+
+import re
+
+from app.utils.password import MIN_PASSWORD_LENGTH
+
+"""Email format regex matching the frontend validator."""
+EMAIL_RE = re.compile(r"^[^\s@]+@[^\s@]+\.[^\s@]+$")
+
+"""US zip code regex matching the frontend validator."""
+ZIP_RE = re.compile(r"^\d{5}$")
+
+
+def serialize_user(user):
+    """Serialize a User model or session dict to a JSON-safe dict.
+
+    Handles both SQLModel instances (from DB queries) and plain dicts
+    (from ``g.user`` populated by ``validate_session``).
+
+    Args:
+        user: A User SQLModel instance or a dict with user fields.
+
+    Returns:
+        A dict with id, email, first_name, last_name, role,
+        email_verified, and created_at.
+    """
+    if isinstance(user, dict):
+        role = user["role"]
+        created_at = user.get("created_at")
+        uid = user["id"]
+        email = user["email"]
+        first_name = user["first_name"]
+        last_name = user["last_name"]
+        email_verified = user["email_verified"]
+    else:
+        role = user.role
+        created_at = user.created_at
+        uid = user.id
+        email = user.email
+        first_name = user.first_name
+        last_name = user.last_name
+        email_verified = user.email_verified
+
+    role_str = role.value if hasattr(role, "value") else str(role)
+    return {
+        "id": str(uid),
+        "email": email,
+        "first_name": first_name,
+        "last_name": last_name,
+        "role": role_str,
+        "email_verified": email_verified,
+        "created_at": created_at.isoformat() if hasattr(created_at, "isoformat") else created_at,
+    }
+
+
+def validate_email(email, errors):
+    """Validate an email field for presence and format.
+
+    Args:
+        email: The email string (may be None).
+        errors: A list to append error dicts to.
+    """
+    if not email:
+        errors.append({"field": "email", "issue": "Required"})
+    if email and not EMAIL_RE.match(email):
+        errors.append({"field": "email", "issue": "Invalid format"})
+
+
+def validate_password(password, errors):
+    """Validate a password field for presence and minimum length.
+
+    Args:
+        password: The password string (may be None).
+        errors: A list to append error dicts to.
+    """
+    if not password:
+        errors.append({"field": "password", "issue": "Required"})
+    if password and len(password) < MIN_PASSWORD_LENGTH:
+        errors.append({"field": "password", "issue": f"Must be at least {MIN_PASSWORD_LENGTH} characters"})
+
+
+def validate_confirm_password(confirm_password, password, errors):
+    """Validate a confirmPassword field for presence and match.
+
+    Args:
+        confirm_password: The confirmation password string (may be None).
+        password: The original password to compare against.
+        errors: A list to append error dicts to.
+    """
+    if not confirm_password:
+        errors.append({"field": "confirmPassword", "issue": "Required"})
+    if confirm_password and password and password != confirm_password:
+        errors.append({"field": "confirmPassword", "issue": "Passwords do not match"})
+
+
+def validate_name(first_name, last_name, errors):
+    """Validate first and last name fields for presence.
+
+    Args:
+        first_name: The first name string (may be None).
+        last_name: The last name string (may be None).
+        errors: A list to append error dicts to.
+    """
+    if not first_name:
+        errors.append({"field": "firstName", "issue": "Required"})
+    if not last_name:
+        errors.append({"field": "lastName", "issue": "Required"})

--- a/backend/tests/blueprints/test_admin.py
+++ b/backend/tests/blueprints/test_admin.py
@@ -37,7 +37,7 @@ def _valid_session_result(role=Role.ADMIN, **user_overrides):
             "last_name": user_overrides.get("last_name", "User"),
             "role": role,
             "email_verified": user_overrides.get("email_verified", True),
-            "created_at": datetime(2026, 1, 1, tzinfo=timezone.utc),
+            "created_at": datetime.now(tz=timezone.utc),
         },
     }
 
@@ -101,7 +101,7 @@ class TestListUsers:
             obj.role = MagicMock()
             obj.role.value = "CLIENT"
             obj.email_verified = i == 0
-            obj.created_at = datetime(2026, 1, i + 1, tzinfo=timezone.utc)
+            obj.created_at = datetime.now(tz=timezone.utc)
             objs.append(obj)
         return objs
 

--- a/backend/tests/blueprints/test_admin.py
+++ b/backend/tests/blueprints/test_admin.py
@@ -37,6 +37,7 @@ def _valid_session_result(role=Role.ADMIN, **user_overrides):
             "last_name": user_overrides.get("last_name", "User"),
             "role": role,
             "email_verified": user_overrides.get("email_verified", True),
+            "created_at": datetime(2026, 1, 1, tzinfo=timezone.utc),
         },
     }
 

--- a/backend/tests/blueprints/test_auth.py
+++ b/backend/tests/blueprints/test_auth.py
@@ -8,6 +8,7 @@ Each test uses a Flask test client with mocked service-layer dependencies.
 """
 
 import uuid
+from datetime import datetime, timezone
 from http import HTTPStatus
 from http.cookies import SimpleCookie
 from unittest.mock import MagicMock, patch
@@ -81,6 +82,7 @@ def _valid_session_result(role=Role.CLIENT, **user_overrides):
             "last_name": user_overrides.get("last_name", "User"),
             "role": role,
             "email_verified": user_overrides.get("email_verified", True),
+            "created_at": datetime(2026, 1, 1, tzinfo=timezone.utc),
         },
     }
 
@@ -128,8 +130,9 @@ class TestSignup:
         assert resp.status_code == HTTPStatus.CREATED
         data = resp.get_json()
         assert data["data"]["user"]["email"] == "new@test.com"
-        assert "id" not in data["data"]["user"]
-        assert "role" not in data["data"]["user"]
+        assert "id" in data["data"]["user"]
+        assert data["data"]["user"]["role"] == "CLIENT"
+        assert "created_at" in data["data"]["user"]
         cookie = _get_cookie(resp, COOKIE_NAME)
         assert cookie is not None
         assert cookie.value == "raw-tok"
@@ -291,8 +294,9 @@ class TestLogin:
         assert resp.status_code == HTTPStatus.OK
         data = resp.get_json()
         assert data["data"]["user"]["email"] == "login@test.com"
-        assert "id" not in data["data"]["user"]
-        assert "role" not in data["data"]["user"]
+        assert "id" in data["data"]["user"]
+        assert data["data"]["user"]["role"] == "CLIENT"
+        assert "created_at" in data["data"]["user"]
         cookie = _get_cookie(resp, COOKIE_NAME)
         assert cookie is not None
         assert cookie.value == "raw-tok"
@@ -417,6 +421,7 @@ class TestMe:
         assert data["data"]["last_name"] == "Doe"
         assert data["data"]["role"] == "CLIENT"
         assert data["data"]["email_verified"] is True
+        assert "created_at" in data["data"]
 
     def test_returns_401_without_auth(self, client):
         """Unauthenticated /me returns 401."""

--- a/backend/tests/blueprints/test_auth.py
+++ b/backend/tests/blueprints/test_auth.py
@@ -82,7 +82,7 @@ def _valid_session_result(role=Role.CLIENT, **user_overrides):
             "last_name": user_overrides.get("last_name", "User"),
             "role": role,
             "email_verified": user_overrides.get("email_verified", True),
-            "created_at": datetime(2026, 1, 1, tzinfo=timezone.utc),
+            "created_at": datetime.now(tz=timezone.utc),
         },
     }
 

--- a/backend/tests/services/test_session_service.py
+++ b/backend/tests/services/test_session_service.py
@@ -137,6 +137,7 @@ class TestValidateSession:
             assert result["user"]["first_name"] == "Alice"
             assert result["user"]["last_name"] == "Smith"
             assert result["user"]["role"] == Role.CLIENT
+            assert "created_at" in result["user"]
 
     def test_missing_token_returns_none(self):
         """validate_session should return None for a token not in DB."""

--- a/frontend/core/api/index.ts
+++ b/frontend/core/api/index.ts
@@ -8,9 +8,7 @@
  */
 export type {
   Role,
-  AuthUser,
   User,
-  AdminUser,
   ApiResponse,
   ApiActionResponse,
   AuthResponse,

--- a/frontend/core/api/index.ts
+++ b/frontend/core/api/index.ts
@@ -6,4 +6,15 @@
  * Public API exports for Flask API types.
  * @module core/api
  */
-export type { Role, User, AuthResponse, ApiError } from './types';
+export type {
+  Role,
+  AuthUser,
+  User,
+  AdminUser,
+  ApiResponse,
+  ApiActionResponse,
+  AuthResponse,
+  PaginatedResponse,
+  ApiError,
+  ApiValidationError,
+} from './types';

--- a/frontend/core/api/index.ts
+++ b/frontend/core/api/index.ts
@@ -1,0 +1,9 @@
+/**
+ * @copyright 2026 Eduardo Turcios. All rights reserved.
+ * Unauthorized use, reproduction, or distribution of this file is strictly prohibited.
+ */
+/**
+ * Public API exports for Flask API types.
+ * @module core/api
+ */
+export type { Role, User, AuthResponse, ApiError } from './types';

--- a/frontend/core/api/types.ts
+++ b/frontend/core/api/types.ts
@@ -25,23 +25,8 @@
 export type Role = 'CLIENT' | 'WORKER' | 'ADMIN';
 
 /**
- * User returned by auth endpoints (login/signup).
- * Excludes `id` and `role` since the frontend does not need them at auth time.
- */
-export interface AuthUser {
-  /** User email address */
-  email: string;
-  /** User first name */
-  first_name: string;
-  /** User last name */
-  last_name: string;
-  /** Whether the user's email has been verified */
-  email_verified: boolean;
-}
-
-/**
- * Full user object returned by `GET /api/auth/me`.
- * Includes `id` and `role` for dashboard and RBAC use.
+ * User object returned by all endpoints (login, signup, me, admin).
+ * Includes `id`, `role`, and `created_at` for a single, consistent user shape.
  */
 export interface User {
   /** Unique user identifier (UUID) */
@@ -56,13 +41,6 @@ export interface User {
   role: Role;
   /** Whether the user's email has been verified */
   email_verified: boolean;
-}
-
-/**
- * Admin-facing user object returned by admin endpoints.
- * Extends {@link User} with a creation timestamp.
- */
-export interface AdminUser extends User {
   /** ISO 8601 timestamp of when the user was created */
   created_at: string;
 }
@@ -88,11 +66,11 @@ export interface ApiActionResponse {
 
 /**
  * Auth response returned by login and signup endpoints.
- * Wraps an {@link AuthUser} in the standard data envelope.
+ * Wraps a {@link User} in the standard data envelope.
  */
 export interface AuthResponse {
   /** The authenticated user wrapped in a data envelope */
-  data: { user: AuthUser };
+  data: { user: User };
 }
 
 /**

--- a/frontend/core/api/types.ts
+++ b/frontend/core/api/types.ts
@@ -10,6 +10,9 @@
  * so cookies are handled automatically. The client has no way to inspect auth
  * state — it relies solely on server responses (e.g., 401) to detect auth problems.
  *
+ * The API uses an envelope pattern: success responses wrap data in `{ data: ... }`,
+ * while error responses use `{ error: { code, message } }`.
+ *
  * @example
  * ```
  * Browser ──RR7 loader/action──▶ fetch() with credentials: 'include' ──▶ Flask API
@@ -22,10 +25,26 @@
 export type Role = 'CLIENT' | 'WORKER' | 'ADMIN';
 
 /**
- * User object returned by the API.
+ * User returned by auth endpoints (login/signup).
+ * Excludes `id` and `role` since the frontend does not need them at auth time.
+ */
+export interface AuthUser {
+  /** User email address */
+  email: string;
+  /** User first name */
+  first_name: string;
+  /** User last name */
+  last_name: string;
+  /** Whether the user's email has been verified */
+  email_verified: boolean;
+}
+
+/**
+ * Full user object returned by `GET /api/auth/me`.
+ * Includes `id` and `role` for dashboard and RBAC use.
  */
 export interface User {
-  /** Unique user identifier */
+  /** Unique user identifier (UUID) */
   id: string;
   /** User email address */
   email: string;
@@ -36,23 +55,95 @@ export interface User {
   /** User role */
   role: Role;
   /** Whether the user's email has been verified */
-  email_verified?: boolean;
+  email_verified: boolean;
 }
 
 /**
- * Wrapper for auth endpoints that return a user.
+ * Admin-facing user object returned by admin endpoints.
+ * Extends {@link User} with a creation timestamp.
+ */
+export interface AdminUser extends User {
+  /** ISO 8601 timestamp of when the user was created */
+  created_at: string;
+}
+
+/**
+ * Generic success response envelope returned by the Flask API.
+ *
+ * @typeParam T - The shape of the wrapped data payload
+ */
+export interface ApiResponse<T> {
+  /** The response payload */
+  data: T;
+}
+
+/**
+ * Success response for actions that produce no meaningful data
+ * (e.g., logout, verify-email, forgot-password, reset-password).
+ */
+export interface ApiActionResponse {
+  /** Status envelope */
+  data: { status: 'completed' };
+}
+
+/**
+ * Auth response returned by login and signup endpoints.
+ * Wraps an {@link AuthUser} in the standard data envelope.
  */
 export interface AuthResponse {
-  /** The authenticated user */
-  user: User;
+  /** The authenticated user wrapped in a data envelope */
+  data: { user: AuthUser };
 }
 
 /**
- * Standard error shape returned by the Flask API.
+ * Paginated response returned by list endpoints (e.g., admin user list).
+ *
+ * @typeParam T - The shape of each item in the list
+ */
+export interface PaginatedResponse<T> {
+  /** Array of items for the current page */
+  data: T[];
+  /** Pagination metadata */
+  meta: {
+    /** Current page number */
+    page: number;
+    /** Number of items per page */
+    pageSize: number;
+    /** Total number of items across all pages */
+    total: number;
+  };
+}
+
+/**
+ * Standard error response returned by the Flask API.
  */
 export interface ApiError {
-  /** Human-readable error message */
-  error: string;
-  /** Optional machine-readable error code */
-  code?: string;
+  /** Error details */
+  error: {
+    /** Machine-readable error code (e.g., `"INVALID_CREDENTIALS"`) */
+    code: string;
+    /** Human-readable error message */
+    message: string;
+  };
+}
+
+/**
+ * Validation error response returned when one or more fields fail validation.
+ * The `code` is always `"VALIDATION_FAILED"`.
+ */
+export interface ApiValidationError {
+  /** Validation error details */
+  error: {
+    /** Always `"VALIDATION_FAILED"` */
+    code: 'VALIDATION_FAILED';
+    /** Human-readable summary message */
+    message: string;
+    /** Per-field validation errors */
+    details: Array<{
+      /** The field that failed validation */
+      field: string;
+      /** Description of the validation issue */
+      issue: string;
+    }>;
+  };
 }

--- a/frontend/core/api/types.ts
+++ b/frontend/core/api/types.ts
@@ -1,0 +1,58 @@
+/**
+ * @copyright 2026 Eduardo Turcios. All rights reserved.
+ * Unauthorized use, reproduction, or distribution of this file is strictly prohibited.
+ */
+/**
+ * Shared TypeScript types for Flask API responses.
+ *
+ * All API communication flows through RR7 client-side loaders and actions.
+ * The browser talks to Flask directly using `fetch()` with `credentials: 'include'`,
+ * so cookies are handled automatically. The client has no way to inspect auth
+ * state — it relies solely on server responses (e.g., 401) to detect auth problems.
+ *
+ * @example
+ * ```
+ * Browser ──RR7 loader/action──▶ fetch() with credentials: 'include' ──▶ Flask API
+ * ```
+ */
+
+/**
+ * User role as returned by the Flask API.
+ */
+export type Role = 'CLIENT' | 'WORKER' | 'ADMIN';
+
+/**
+ * User object returned by the API.
+ */
+export interface User {
+  /** Unique user identifier */
+  id: string;
+  /** User email address */
+  email: string;
+  /** User first name */
+  first_name: string;
+  /** User last name */
+  last_name: string;
+  /** User role */
+  role: Role;
+  /** Whether the user's email has been verified */
+  email_verified?: boolean;
+}
+
+/**
+ * Wrapper for auth endpoints that return a user.
+ */
+export interface AuthResponse {
+  /** The authenticated user */
+  user: User;
+}
+
+/**
+ * Standard error shape returned by the Flask API.
+ */
+export interface ApiError {
+  /** Human-readable error message */
+  error: string;
+  /** Optional machine-readable error code */
+  code?: string;
+}


### PR DESCRIPTION
## Summary
- Add `Role`, `User`, `AuthResponse`, and `ApiError` types in `frontend/core/api/types.ts`
- Add barrel exports in `frontend/core/api/index.ts`
- Types establish the contract for RR7 loaders/actions communicating with the Flask backend via `fetch()` with `credentials: 'include'`

## Test plan
- [x] `npm run typecheck` passes
- [x] Copyright headers added via `npm run copyright`

Closes #40